### PR TITLE
Cleanup figure to imgsrc

### DIFF
--- a/marspylib/__init__.py
+++ b/marspylib/__init__.py
@@ -1,9 +1,8 @@
-import pandas as pd
-import numpy as np
 import matplotlib.pyplot as plt
-import seaborn as sns
+import io
+import base64
+import sj
 import math
-
 
 def hallo_world():
     print('hallo world')
@@ -20,7 +19,7 @@ def figure_to_imgsrc(figure):
     imageBytes = io.BytesIO()
     figure.savefig(imageBytes)
     imageBytes.seek(0)
-    imgsrc = imagej.sj.to_java('data:image/png;base64,' + base64.b64encode(imageBytes.read()).decode("utf-8"))
+    imgsrc = sj.to_java('data:image/png;base64,' + base64.b64encode(imageBytes.read()).decode("utf-8"))
     plt.close(figure)
     return imgsrc
 

--- a/marspylib/__init__.py
+++ b/marspylib/__init__.py
@@ -1,7 +1,6 @@
 import matplotlib.pyplot as plt
 import io
 import base64
-import sj
 import math
 
 def hallo_world():
@@ -19,7 +18,7 @@ def figure_to_imgsrc(figure):
     imageBytes = io.BytesIO()
     figure.savefig(imageBytes)
     imageBytes.seek(0)
-    imgsrc = sj.to_java('data:image/png;base64,' + base64.b64encode(imageBytes.read()).decode("utf-8"))
+    imgsrc = 'data:image/png;base64,' + base64.b64encode(imageBytes.read()).decode("utf-8")
     plt.close(figure)
     return imgsrc
 

--- a/marspylib/fret/__init__.py
+++ b/marspylib/fret/__init__.py
@@ -1,7 +1,4 @@
-import pandas as pd
 import numpy as np
-import matplotlib.pyplot as plt
-import seaborn as sns
 
 def hallo_world():
     print('hallo world fret')

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from os import path
 setup(
     name='marspylib',
     packages=find_packages(),
-    version="0.1.0",
+    version="0.1.1",
     description='Library containing python functions to interact with Mars Archives',
     author='Karl Duderstadt, Nadia Huisjes, Thomas Retzer',
     url='https://github.com/duderstadt-lab/marspylib',

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,8 +1,17 @@
 import pytest
 import marspylib
-
+import matplotlib.pyplot as plt
 
 ## To add: unit tests figure_to_imgsrc(), gauss()
+
+def test_figure_to_imgsrc():
+    '''Test if the generated figure is correctly converted to an img src data string'''
+    plt.plot([1, 2, 3, 4])
+    plt.ylabel('some numbers')
+    fig = plt.gcf()
+    fig.set_size_inches(0.1, 0.1)
+    fig.set_dpi(50)
+    assert figure_to_imgsrc(fig) == 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAcAAAAHCAYAAADEUlfTAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAlklEQVR4nHWOIQrCYABG32+w/EkwCAtDMCwq/00sHsLugmcYiHcwGSxL6hF+g7YNDzDQ5IqK8zPoxOKrDx7PSOIfBvDWWhdFEQCn8kZxuXIvjmck4ZyTJM23ucI41XixE+AbdSJZZySbnOEgYDbqf9O+FXQVxqkmy70e1VN6j3gk0ez0NF0dVH1ELY0kjDElkP2MtgH7Ap5xTn0Bv6XKAAAAAElFTkSuQmCC'
 
 def test_flatten():
     '''Test if the test list returns the correct flattened list'''


### PR DESCRIPTION
@NadiaHuisjes I cleaned up the figure_to_imgsrc function and added a unit test. In the process, I also removed some imports that were not used in several files. Finally, I removed the conversion of the final html data string to a java string because this is done by the script runner already and leaving it out removes scyjava as a dependency. This way a single instance of that library is used all in one place. This still needs testing with the mars widgets but is the right way, I think.

Therefore, I believe this is more or less ready for merge. Can you perhaps test this by cloning my fork and testing, I wasn't entirely sure how to go about that.